### PR TITLE
Add set filter to advanced filters

### DIFF
--- a/src/app/collection/decks/[id]/page.js
+++ b/src/app/collection/decks/[id]/page.js
@@ -55,6 +55,9 @@ export default function DeckViewPage() {
   const [cmcMode, setCmcMode] = useState('exact') // exact, gte, lte
   const [selectedColors, setSelectedColors] = useState([]) // Array of selected color letters: W, U, B, R, G
   
+  // Set Filter
+  const [selectedSet, setSelectedSet] = useState('') // Selected set code
+  
   // Card modal for chart interactions
   const [showCardModal, setShowCardModal] = useState(false)
   const [modalCards, setModalCards] = useState([])
@@ -446,6 +449,11 @@ export default function DeckViewPage() {
       if (!hasAllColors) return false
     }
     
+    // Apply set filter
+    if (selectedSet !== '') {
+      if (cardData.set !== selectedSet) return false
+    }
+    
     return true
   }).sort((a, b) => {
     const cardA = a.cardData
@@ -692,6 +700,7 @@ export default function DeckViewPage() {
                     if (filterBy !== 'all') activeFilters++
                     if (cmcValue !== '') activeFilters++
                     if (selectedColors.length > 0) activeFilters++
+                    if (selectedSet !== '') activeFilters++
                     
                     return activeFilters > 0 ? (
                       <span className="absolute -top-2 -right-2 bg-blue-600 text-white text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center">
@@ -1067,6 +1076,40 @@ export default function DeckViewPage() {
                   </div>
                 </div>
 
+                {/* Set Filter */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Set
+                  </label>
+                  <Select
+                    className="w-full"
+                    value={selectedSet}
+                    onChange={(e) => setSelectedSet(e.target.value)}
+                  >
+                    <option value="">All Sets</option>
+                    {/* Generate unique sets from deck cards */}
+                    {deck?.cards
+                      ?.filter(deckCard => deckCard.cardData)
+                      .reduce((uniqueSets, deckCard) => {
+                        const card = deckCard.cardData
+                        if (card.set && !uniqueSets.some(s => s.code === card.set)) {
+                          uniqueSets.push({
+                            code: card.set,
+                            name: card.setName || card.set
+                          })
+                        }
+                        return uniqueSets
+                      }, [])
+                      .sort((a, b) => a.name.localeCompare(b.name))
+                      .map(set => (
+                        <option key={set.code} value={set.code}>
+                          {set.name}
+                        </option>
+                      ))
+                    }
+                  </Select>
+                </div>
+
                 {/* Sort By */}
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -1094,6 +1137,7 @@ export default function DeckViewPage() {
                     setCmcValue('')
                     setCmcMode('exact')
                     setSelectedColors([])
+                    setSelectedSet('')
                     setSearchQuery('')
                   }}
                   className="flex-1 px-4 py-2 text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors duration-200"

--- a/src/app/collection/page.js
+++ b/src/app/collection/page.js
@@ -32,6 +32,9 @@ export default function CollectionPage() {
   // Color Filters
   const [selectedColors, setSelectedColors] = useState([]) // Array of selected color letters: W, U, B, R, G
   
+  // Set Filter
+  const [selectedSet, setSelectedSet] = useState('') // Selected set code
+  
   // Stats
   const [stats, setStats] = useState({
     totalCards: 0,
@@ -137,6 +140,13 @@ export default function CollectionPage() {
         return selectedColors.every(color => cardColorIdentity.includes(color))
       })
     }
+    
+    // Apply set filter
+    if (selectedSet !== '') {
+      filtered = filtered.filter(item => {
+        return item.set === selectedSet
+      })
+    }
 
     // Apply sorting
     filtered.sort((a, b) => {
@@ -161,7 +171,7 @@ export default function CollectionPage() {
     })
 
     setFilteredCollection(filtered)
-  }, [collection, searchQuery, filterBy, sortBy, cmcValue, cmcMode, selectedColors])
+  }, [collection, searchQuery, filterBy, sortBy, cmcValue, cmcMode, selectedColors, selectedSet])
 
   const handleRemoveCard = async (collectionItem) => {
     try {
@@ -291,6 +301,7 @@ export default function CollectionPage() {
                 if (filterBy !== 'all') activeFilters++
                 if (cmcValue !== '') activeFilters++
                 if (selectedColors.length > 0) activeFilters++
+                if (selectedSet !== '') activeFilters++
                 
                 return activeFilters > 0 ? (
                   <span className="absolute -top-2 -right-2 bg-blue-600 text-white text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center">
@@ -314,10 +325,10 @@ export default function CollectionPage() {
           <div className="text-center py-16">
             <div className="text-6xl mb-4">📦</div>
             <h3 className="text-2xl font-bold text-gray-900 mb-4">
-              {searchQuery || filterBy !== 'all' || cmcValue !== '' || selectedColors.length > 0 ? 'No cards match your filters' : 'No cards in collection'}
+              {searchQuery || filterBy !== 'all' || cmcValue !== '' || selectedColors.length > 0 || selectedSet !== '' ? 'No cards match your filters' : 'No cards in collection'}
             </h3>
             <p className="text-gray-600 mb-8">
-              {searchQuery || filterBy !== 'all' || cmcValue !== '' || selectedColors.length > 0
+              {searchQuery || filterBy !== 'all' || cmcValue !== '' || selectedColors.length > 0 || selectedSet !== ''
                 ? 'Try adjusting your search or filter criteria'
                 : 'Start building your collection by searching for cards'}
             </p>
@@ -497,6 +508,38 @@ export default function CollectionPage() {
                   </div>
                 </div>
 
+                {/* Set Filter */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Set
+                  </label>
+                  <Select
+                    className="w-full"
+                    value={selectedSet}
+                    onChange={(e) => setSelectedSet(e.target.value)}
+                  >
+                    <option value="">All Sets</option>
+                    {/* Generate unique sets from collection */}
+                    {collection
+                      .reduce((uniqueSets, card) => {
+                        if (card.set && !uniqueSets.some(s => s.code === card.set)) {
+                          uniqueSets.push({
+                            code: card.set,
+                            name: card.setName || card.set
+                          })
+                        }
+                        return uniqueSets
+                      }, [])
+                      .sort((a, b) => a.name.localeCompare(b.name))
+                      .map(set => (
+                        <option key={set.code} value={set.code}>
+                          {set.name}
+                        </option>
+                      ))
+                    }
+                  </Select>
+                </div>
+
                 {/* Sort By */}
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -524,6 +567,7 @@ export default function CollectionPage() {
                     setCmcValue('')
                     setCmcMode('exact')
                     setSelectedColors([])
+                    setSelectedSet('')
                     setSearchQuery('')
                   }}
                   className="flex-1 px-4 py-2 text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors duration-200"


### PR DESCRIPTION
## 🎯 Feature Overview

This PR adds a new **Set Filter** to the advanced filtering options in both the Collection and Deck views, allowing users to filter cards by MTG set.

## ✨ Key Features

### 🔍 Set Filter Functionality
- **Dropdown selection**: Choose from sets that exist in your collection/deck
- **Full set names**: Displays complete set names (e.g., "Throne of Eldraine") instead of just codes ("ELD")
- **Dynamic options**: Filter options are generated from cards actually in your collection/deck
- **Alphabetical sorting**: Set names are sorted alphabetically for easy browsing
- **Smart integration**: Works seamlessly with existing filters (search, type, color, CMC)

### 📊 User Experience
- **Consistent UI**: Matches existing advanced filter design patterns
- **Active filter indication**: Counts toward the filter badge number
- **Clear all support**: Included in "Clear All Filters" functionality
- **Real-time filtering**: Updates results immediately when selection changes

## 🔧 Technical Implementation

### Architecture
- **Collection page**: Filters from user's complete collection data
- **Deck page**: Filters from cards in the specific deck
- **Efficient processing**: Uses reduce() to generate unique set list from card data
- **Data structure**: Leverages existing '!'=0
'#'=0
'$'=74307
'*'=(  )
-=569Xfikls
0=-zsh
'?'=0
@=(  )
ARGC=0
CDPATH=''
COLORTERM=truecolor
COLUMNS=119
COMMAND_MODE=unix2003
CONDA_CHANGEPS1=false
CPUTYPE=arm64
DCS_END=$'\M-\C-\'
DCS_JSON_MARKER=d
DCS_START=$'\C-[P$'
DISABLE_AUTO_TITLE=true
EGID=20
EPOCHREALTIME
EUID=501
FIGNORE=''
FPATH=/opt/homebrew/share/zsh/site-functions:/usr/local/share/zsh/site-functions:/usr/share/zsh/site-functions:/usr/share/zsh/5.9/functions
FUNCNEST=700
GID=20
HISTCHARS='!^#'
HISTCMD=988
HISTFILE=/Users/ttom/.zsh_history
HISTSIZE=2000
HOME=/Users/ttom
HOMEBREW_CELLAR=/opt/homebrew/Cellar
HOMEBREW_PREFIX=/opt/homebrew
HOMEBREW_REPOSITORY=/opt/homebrew
HOST=Mac.mynet
IFS=$' \t\n\C-@'
INFOPATH=/opt/homebrew/share/info:
KEYBOARD_HACK=''
KEYTIMEOUT=40
LANG=en_GB.UTF-8
LINENO=839
LINES=41
LISTMAX=100
LOGNAME=ttom
LaunchInstanceID=7DF59035-5360-420F-80F4-FCF41EA8842C
MACHTYPE=x86_64
MAILCHECK=60
MAILPATH=''
MANPATH=''
MODULE_PATH=/usr/lib/zsh/5.9
NULLCMD=cat
NVIM_RE='([[:space:]]|^)nvim([[:space:]]|$)'
OLDPWD=/Users/ttom/Documents/mtg-proj
OPTARG=''
OPTIND=1
ORIGINAL_PROMPT='%n@%m %1~ %# '
ORIGINAL_PS2='%_> '
OSC_END=$'\C-G'
OSC_END_GENERATOR_OUTPUT=$'\C-[]9277;B\C-G'
OSC_PARAM_SEPARATOR=';'
OSC_RESET_GRID=$'\C-[]9279\C-G'
OSC_START=$'\C-[]9278;'
OSC_START_GENERATOR_OUTPUT=$'\C-[]9277;A\C-G'
OSTYPE=darwin24.0
PATH=/opt/homebrew/opt/postgresql@15/bin:/opt/homebrew/opt/openjdk@17/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin
POWERLEVEL9K_INSTANT_PROMPT=off
PPID=74296
PROMPT=$'%{\C-[]133;A\C-G%n@%m %1~ %# \C-[]133;B\C-G%}'
PROMPT2='%_> '
PROMPT3='?# '
PROMPT4='+%N:%i> '
PS1=$'%{\C-[]133;A\C-G%n@%m %1~ %# \C-[]133;B\C-G%}'
PS2='%_> '
PS3='?# '
PS4='+%N:%i> '
PSVAR=''
PWD=/Users/ttom/Documents/mtg-proj
RANDOM=580
READNULLCMD=more
RPROMPT='%{%}'
SAVED_PROMPT='%n@%m %1~ %# '
SAVED_RPROMPT='%{%}'
SAVEHIST=1000
SECONDS=187521
SECURITYSESSIONID=186ab
SHELL=/bin/zsh
SHLVL=7
SPROMPT='zsh: correct '\''%R'\'' to '\''%r'\'' [nyae]? '
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.YrFWOpS0JM/Listeners
SSH_SOCKET_DIR='~/.ssh'
TEMPLATE_PREFIX=warptmp.
TERM=xterm-256color
TERM_PROGRAM=WarpTerminal
TERM_PROGRAM_VERSION=v0.2025.09.03.08.11.stable_02
TIMEFMT='%J  %U user %S system %P cpu %*E total'
TMPDIR=/var/folders/k1/q8kjvfjn0pv7xnwp53cp8dvr0000gn/T/
TMPPREFIX=/tmp/zsh
TRY_BLOCK_ERROR=-1
TRY_BLOCK_INTERRUPT=-1
TTY=/dev/ttys001
TTYIDLE=0
UID=501
USER=ttom
USERNAME=ttom
VENDOR=apple
WARP_BOOTSTRAPPED=1
WARP_HONOR_PS1=0
WARP_IS_LOCAL_SHELL_SESSION=1
WARP_SESSION_ID=175709022128316
WARP_USE_SSH_WRAPPER=1
WARP_USING_WINDOWS_CON_PTY=false
WATCH
WORDCHARS='*?_-.[]~=/&;!#$%^(){}<>'
XPC_FLAGS=0x0
XPC_SERVICE_NAME=0
ZLE_BINDKEY='bindkey -A emacs main'
ZSH_ARGZERO=-zsh
ZSH_EVAL_CONTEXT=toplevel:cmdsubst
ZSH_NAME=zsh
ZSH_PATCHLEVEL=zsh-5.9-0-g73d3173
ZSH_SUBSHELL=1
ZSH_THEME_TERM_TAB_TITLE_IDLE_REMOTE='%m:%~'
ZSH_THEME_TERM_TITLE_IDLE='%~'
ZSH_VERSION=5.9
_=set
_WARP_GENERATOR_PIDS_COMPLETED_TMP_FILE=/var/folders/k1/q8kjvfjn0pv7xnwp53cp8dvr0000gn/T/tmp.IrNRPUYffe
_WARP_GENERATOR_PIDS_STARTED_TMP_FILE=/var/folders/k1/q8kjvfjn0pv7xnwp53cp8dvr0000gn/T/tmp.NwEDycc1c7
__CFBundleIdentifier=dev.warp.Warp-Stable
__CF_USER_TEXT_ENCODING=0x1F5:0:2
aliases
argv=(  )
block_id=53
builtins
cdpath=(  )
commands
dirstack
dis_aliases
dis_builtins
dis_functions
dis_functions_source
dis_galiases
dis_patchars
dis_reswords
dis_saliases
fignore=(  )
fpath=( /opt/homebrew/share/zsh/site-functions /usr/local/share/zsh/site-functions /usr/share/zsh/site-functions /usr/share/zsh/5.9/functions )
funcfiletrace
funcsourcetrace
funcstack
functions
functions_source
functrace
galiases
histchars='!^#'
history
historywords
i=shinstdin
jobdirs
jobstates
jobtexts
kernel_name=Darwin
key=( [Backspace]=$'\C-H' [Delete]=$'\C-[[3~' [Down]=$'\C-[OB' [End]=$'\C-[OF' [F1]=$'\C-[OP' [F10]=$'\C-[[21~' [F11]=$'\C-[[23~' [F12]=$'\C-[[24~' [F13]=$'\C-[[1;2P' [F14]=$'\C-[[1;2Q' [F15]=$'\C-[[1;2R' [F16]=$'\C-[[1;2S' [F17]=$'\C-[[15;2~' [F18]=$'\C-[[17;2~' [F19]=$'\C-[[18;2~' [F2]=$'\C-[OQ' [F20]=$'\C-[[19;2~' [F3]=$'\C-[OR' [F4]=$'\C-[OS' [F5]=$'\C-[[15~' [F6]=$'\C-[[17~' [F7]=$'\C-[[18~' [F8]=$'\C-[[19~' [F9]=$'\C-[[20~' [Home]=$'\C-[OH' [Insert]=$'\C-[[2~' [Left]=$'\C-[OD' [PageDown]=$'\C-[[6~' [PageUp]=$'\C-[[5~' [Right]=$'\C-[OC' [Up]=$'\C-[OA' )
keymaps
mailpath=(  )
manpath=(  )
module_path=( /usr/lib/zsh/5.9 )
modules
motd_file=/usr/lib/motd.dynamic
nameddirs
options
os_category=MacOS
parameters
patchars
path=( /opt/homebrew/opt/postgresql@15/bin /opt/homebrew/opt/openjdk@17/bin /opt/homebrew/bin /opt/homebrew/sbin /usr/local/bin /System/Cryptexes/App/usr/bin /usr/bin /bin /usr/sbin /sbin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin )
pids=(  )
pipestatus=( 0 )
precmd_functions=( warp_set_title_idle_on_precmd warp_precmd warp_update_prompt_vars )
preexec_functions=( warp_set_title_active_on_preexec warp_preexec )
prompt=$'%{\C-[]133;A\C-G%n@%m %1~ %# \C-[]133;B\C-G%}'
psvar=(  )
rcfiles_end_time=1757090221.6353569031
rcfiles_start_time=1757090221.6036350727
reswords
saliases
shell_options=$'combiningchars\ninteractive\ninteractivecomments\nlogin\nnorcs\nshinstdin'
shell_plugins=(  )
signals=( EXIT HUP INT QUIT ILL TRAP ABRT EMT FPE KILL BUS SEGV SYS PIPE ALRM TERM URG STOP TSTP CONT CHLD TTIN TTOU IO XCPU XFSZ VTALRM PROF WINCH INFO USR1 USR2 ZERR DEBUG )
status=0
termcap
terminfo
title='%25<..<cd'
userdirs
usergroups
watch
widgets
zle_bracketed_paste=( $'\C-[[?2004h' $'\C-[[?2004l' )
zsh_eval_context=( toplevel cmdsubst )
zsh_scheduled_events
zshaddhistory_functions=( _warp_zshaddhistory ) (code) and  (full name) fields

### Code Quality
- ✅ **Reuses existing patterns**: Follows same structure as other filters
- ✅ **No breaking changes**: All existing functionality preserved
- ✅ **Type consistency**: Maintains existing data flow patterns
- ✅ **Performance optimized**: Minimal impact on rendering performance

## 🧪 Testing

- ✅ **Build verification**: Next.js build passes successfully
- ✅ **Filter integration**: Works correctly with all existing filters
- ✅ **UI consistency**: Matches design patterns across collection and deck pages
- ✅ **Data accuracy**: Shows correct set names from card database

## 📋 Files Changed

-  - Added set filter to collection advanced filters
-  - Added set filter to deck advanced filters

## 🚀 User Scenarios

Users can now:
1. **Browse by expansion**: Quickly find all cards from specific MTG sets
2. **Deck analysis**: See which cards in a deck come from particular sets
3. **Collection organization**: Filter collection by favorite or recent sets
4. **Combo filtering**: Combine set filter with type, color, and CMC filters

## 💡 Example Usage

- Filter collection to show only "Throne of Eldraine" cards
- In a deck, see all "Core Set 2021" cards combined with creatures only
- Find all blue instants from "Strixhaven" in your collection
- Analyze mana curve for cards from a specific set in your deck

---

Ready for review! This enhancement provides users with a powerful new way to organize and filter their MTG cards by set. 🎉