### PR TITLE
Add click-outside-to-close functionality to advanced filters modal

### DIFF
--- a/src/app/collection/decks/[id]/page.js
+++ b/src/app/collection/decks/[id]/page.js
@@ -400,6 +400,12 @@ export default function DeckViewPage() {
     const title = cmcValue >= 10 ? `CMC 10+ Cards (${count})` : `CMC ${cmcValue} Cards (${count})`
     openCardModal(cards, title)
   }
+  
+  const handleAdvancedFiltersBackdropClick = (e) => {
+    if (e.target === e.currentTarget) {
+      setShowAdvancedFilters(false)
+    }
+  }
 
   // Filter and sort deck cards based on all criteria
   const filteredCards = deck?.cards?.filter(deckCard => {
@@ -939,7 +945,10 @@ export default function DeckViewPage() {
       
       {/* Advanced Filters Modal */}
       {showAdvancedFilters && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+        <div 
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50"
+          onClick={handleAdvancedFiltersBackdropClick}
+        >
           <div className="bg-white rounded-xl shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto">
             <div className="p-6">
               <div className="flex items-center justify-between mb-6">

--- a/src/app/collection/page.js
+++ b/src/app/collection/page.js
@@ -195,6 +195,12 @@ export default function CollectionPage() {
       setTimeout(() => setNotification(null), 3000)
     }
   }
+  
+  const handleAdvancedFiltersBackdropClick = (e) => {
+    if (e.target === e.currentTarget) {
+      setShowAdvancedFilters(false)
+    }
+  }
 
   if (isLoading) {
     return (
@@ -371,7 +377,10 @@ export default function CollectionPage() {
 
       {/* Advanced Filters Modal */}
       {showAdvancedFilters && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+        <div 
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50"
+          onClick={handleAdvancedFiltersBackdropClick}
+        >
           <div className="bg-white rounded-xl shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto">
             <div className="p-6">
               <div className="flex items-center justify-between mb-6">


### PR DESCRIPTION
## 🎯 Problem

The advanced filters modal was inconsistent with other modals in the application - it could only be closed by:
- ❌ Clicking the X button in top-right corner  
- ❌ Clicking Apply Filters button

But **not** by clicking outside the modal, which is standard expected behavior for modals.

## ✨ Solution

Added click-outside-to-close functionality to make the advanced filters modal consistent with other modals in the app.

## 🔧 Implementation Details

### Technical Changes
- Collection Page: Added handleAdvancedFiltersBackdropClick function
- Deck Page: Added handleAdvancedFiltersBackdropClick function
- Modal Backdrop: Added onClick handler to backdrop div
- Click Detection: Uses e.target === e.currentTarget pattern (same as existing modals)

### Behavior
- ✅ Click outside modal: Closes the modal
- ✅ Click X button: Still works (existing functionality)
- ✅ Click Apply Filters: Still works (existing functionality)
- ✅ Click inside modal content: Does NOT close modal (prevents accidental closure)

## 🧪 Testing

- ✅ Build verification: Next.js build passes successfully
- ✅ Consistency check: Follows same pattern as existing modals
- ✅ Backwards compatibility: All existing close methods still work
- ✅ UX improvement: Modal behavior now matches user expectations

## 📋 Files Changed

- src/app/collection/page.js - Added backdrop click handler
- src/app/collection/decks/[id]/page.js - Added backdrop click handler

## 💡 User Experience Impact

### Before
- Users had to specifically click X or Apply Filters to close modal
- Clicking outside modal did nothing (frustrating UX)
- Inconsistent with other modals in the app

### After
- ✅ Natural modal behavior - click outside to close
- ✅ Consistent UX across all modals
- ✅ Improved accessibility and user experience
- ✅ All existing functionality preserved

Quick fix for better user experience! 🎉